### PR TITLE
Preventing user from selecting less than 4 of each type of perk

### DIFF
--- a/lib/pages/buildConfigurator.dart
+++ b/lib/pages/buildConfigurator.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import '../widgets/perk.dart';
 import '../utilities.dart' as Utils;
+import '../widgets/perk.dart';
 
 
 class BuildConfiguration extends StatefulWidget {
@@ -29,6 +29,28 @@ class _BuildConfigurationState extends State<BuildConfiguration> {
     loadList();
   }
 
+  void onSaveButtonPressed(BuildContext context) {
+    int selectedKillerPerks = killerPerks.where((perk) => perk.isEnabled).toList().length;
+    int selectedSurvivorPerks = survivorPerks.where((perk) => perk.isEnabled).toList().length;
+
+    ScaffoldState scaffold = Scaffold.of(context);
+
+    scaffold.removeCurrentSnackBar();
+
+    if (selectedKillerPerks >= 4 && selectedSurvivorPerks >=4) {
+      Navigator.pop(context, [killerPerks,survivorPerks]);
+    }
+    else if (selectedKillerPerks < 4 && selectedSurvivorPerks < 4) {
+      scaffold.showSnackBar(SnackBar(content: Text('You must select at least 4 killer and at least 4 survivor perks')));
+    }
+    else if (selectedKillerPerks < 4) {
+      scaffold.showSnackBar(SnackBar(content: Text('You must select at least 4 killer perks')));
+    }
+    else {
+      scaffold.showSnackBar(SnackBar(content: Text('You must select at least 4 survivor perks')));
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
 
@@ -36,6 +58,7 @@ class _BuildConfigurationState extends State<BuildConfiguration> {
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
     ]);
+
     return DefaultTabController(
       length: 2,
       child: Scaffold(
@@ -47,97 +70,95 @@ class _BuildConfigurationState extends State<BuildConfiguration> {
           ]),
           automaticallyImplyLeading: false,
           backgroundColor: Color(0xff21213b),
-          title: Text('Perk Configuration',style: TextStyle(color: Colors.white),),
+          title: Text('Perk Configuration', style: TextStyle(color: Colors.white)),
         ),
-        body: TabBarView(
-          children: [
-            Column(
-            children: <Widget>[
-              Container(
-                height: MediaQuery.of(context).size.height - 200 ,
-                child: ListView(
+        body: Builder(
+          builder: (BuildContext context) {
+            return TabBarView(
+              children: [
+                Column(
                   children: <Widget>[
-                    for(var item in survivorPerks)
-                      CheckboxListTile(
-                        title: Text(item.perkName, style: TextStyle(color: Colors.white),),
-                        value: item.isEnabled,
-                        onChanged: (bool value) {
-                            setState(() {
-                              survivorPerks[item.id].isEnabled = value;
-                            });
-                        },
-                      ),
-                    ],
-                ),
-              ),
-              Expanded(
-                child: Container(
-                  alignment: Alignment(0, 1),
-                  child: SizedBox(
-                    width: double.infinity,
-                    height: 75,
-                    child: FlatButton(
-                      onPressed: () {
-                        Navigator.pop(context, [killerPerks,survivorPerks]);
-                      },
-                      child: Text(
-                        'Save',
-                        style: TextStyle(fontSize: 22.0),
-                      ),
-                      color: Colors.redAccent,
-                      textColor: Colors.white,
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-            Column(
-              children: <Widget>[
-                Container(
-                  height: MediaQuery.of(context).size.height - 200 ,
-                  child: ListView(
-                    children: <Widget>[
-                      for(var item in killerPerks)
-                        CheckboxListTile(
-                          title: Text(item.perkName, style: TextStyle(color: Colors.white),),
-                          value: item.isEnabled,
-                          onChanged: (bool value) {
-                            setState(() {
-                              killerPerks[item.id].isEnabled = value;
-                            });
-                          },
-                        ),
-                    ],
-                  ),
-                ),
-                Expanded(
-                  child: Container(
-                    alignment: Alignment(0, 1),
-                    child: SizedBox(
-                      width: double.infinity,
-                      height: 75,
-                      child: FlatButton(
-                        onPressed: () {
-                          Navigator.pop(context, [killerPerks,survivorPerks]);
-                        },
-                        child: Text(
-                          'Save',
-                          style: TextStyle(fontSize: 22.0),
-                        ),
-                        color: Colors.redAccent,
-                        textColor: Colors.white,
+                    Container(
+                      height: MediaQuery.of(context).size.height - 200,
+                      child: ListView(
+                        children: <Widget>[
+                          for(var item in survivorPerks)
+                            CheckboxListTile(
+                              title: Text(item.perkName, style: TextStyle(color: Colors.white)),
+                              value: item.isEnabled,
+                              onChanged: (bool value) {
+                                setState(() {
+                                  survivorPerks[item.id].isEnabled = value;
+                                });
+                              },
+                            ),
+                        ],
                       ),
                     ),
-                  ),
+                    Expanded(
+                      child: Container(
+                        alignment: Alignment(0, 1),
+                        child: SizedBox(
+                          width: double.infinity,
+                          height: 75,
+                          child: FlatButton(
+                            onPressed: () => onSaveButtonPressed(context),
+                            child: Text(
+                              'Save',
+                              style: TextStyle(fontSize: 22.0),
+                            ),
+                            color: Colors.redAccent,
+                            textColor: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                Column(
+                  children: <Widget>[
+                    Container(
+                      height: MediaQuery.of(context).size.height - 200,
+                      child: ListView(
+                        children: <Widget>[
+                          for (var item in killerPerks)
+                            CheckboxListTile(
+                              title: Text(item.perkName, style: TextStyle(color: Colors.white)),
+                              value: item.isEnabled,
+                              onChanged: (bool value) {
+                                setState(() {
+                                  killerPerks[item.id].isEnabled = value;
+                                });
+                              },
+                            ),
+                        ],
+                      ),
+                    ),
+                    Expanded(
+                      child: Container(
+                        alignment: Alignment(0, 1),
+                        child: SizedBox(
+                          width: double.infinity,
+                          height: 75,
+                          child: FlatButton(
+                            onPressed: () => onSaveButtonPressed(context),
+                            child: Text(
+                              'Save',
+                              style: TextStyle(fontSize: 22.0),
+                            ),
+                            color: Colors.redAccent,
+                            textColor: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ],
-            ),
-          ],
-
+            );
+          }
         ),
       ),
     );
   }
 }
-

--- a/lib/pages/perkPage.dart
+++ b/lib/pages/perkPage.dart
@@ -98,6 +98,10 @@ class _PerkPageState extends State<PerkPage> {
                         MaterialPageRoute(builder: (context) => BuildConfiguration())
                     );
 
+                    if(returnedList == null) {
+                      return;
+                    }
+
                     var survivorList = returnedList[1];
                     var killerList = returnedList[0];
 
@@ -133,13 +137,13 @@ class _PerkPageState extends State<PerkPage> {
                   Expanded(
                     child: PerkTile(
                         name: perkList[randomlySelectedPerks.elementAt(0) - 1].perkName,
-                        iconPath: 'images/$selectedType${randomlySelectedPerks.elementAt(0)}.png'
+                        iconPath: 'images/$selectedType${perkList[randomlySelectedPerks.elementAt(0) - 1].iconName}'
                     ),
                   ),
                   Expanded(
                     child: PerkTile(
                         name: perkList[randomlySelectedPerks.elementAt(1) - 1].perkName,
-                        iconPath: 'images/$selectedType${randomlySelectedPerks.elementAt(1)}.png'
+                        iconPath: 'images/$selectedType${perkList[randomlySelectedPerks.elementAt(1) - 1].iconName}'
                     ),
                   ),
                 ],
@@ -153,13 +157,13 @@ class _PerkPageState extends State<PerkPage> {
                 Expanded(
                   child: PerkTile(
                       name: perkList[randomlySelectedPerks.elementAt(2) - 1].perkName,
-                      iconPath: 'images/$selectedType${randomlySelectedPerks.elementAt(2)}.png'
+                      iconPath: 'images/$selectedType${perkList[randomlySelectedPerks.elementAt(2) - 1].iconName}'
                   ),
                 ),
                 Expanded(
                   child: PerkTile(
                       name: perkList[randomlySelectedPerks.elementAt(3) - 1].perkName,
-                      iconPath: 'images/$selectedType${randomlySelectedPerks.elementAt(3)}.png'
+                      iconPath: 'images/$selectedType${perkList[randomlySelectedPerks.elementAt(3) - 1].iconName}'
                   ),
                 ),
               ],

--- a/lib/widgets/perk.dart
+++ b/lib/widgets/perk.dart
@@ -1,24 +1,28 @@
 class Perk {
   String perkName;
+  String iconName;
   bool isEnabled;
   int id;
 
-  Perk(this.perkName, this.isEnabled,this.id);
+  Perk(this.perkName, this.isEnabled,this.id, this.iconName);
 
   Perk.fromJson(Map<String, dynamic> m) {
     perkName = m['perkName'];
     isEnabled = m['isEnabled'];
     id = m['id'];
+    iconName = m['iconName'];
   }
 
   String get _perkName => perkName;
   bool get _isEnabled => isEnabled;
   int get _id => id;
+  String get _iconName => iconName;
 
   Map<String, dynamic> toJson() => {
     'perkName': _perkName,
     'isEnabled': _isEnabled,
-    'id': _id
+    'id': _id,
+    'iconName': _iconName,
   };
 }
 
@@ -49,7 +53,7 @@ List survivorList = [
 List<Perk> returnAll() {
   List<Perk> allPerks = List<Perk>();
   for(var i=0;i<fullList.length;i++) {
-    allPerks.add(Perk(fullList[i], true,i));
+    allPerks.add(Perk(fullList[i], true,i,"${i + 1}.png"));
   }
   return allPerks;
 }
@@ -57,7 +61,7 @@ List<Perk> returnAll() {
 List<Perk> returnKiller() {
   List<Perk> killerPerks = List<Perk>();
   for(var i=0;i<killerList.length;i++) {
-    killerPerks.add(Perk(killerList[i],true,i));
+    killerPerks.add(Perk(killerList[i],true,i,"${i + 1}.png"));
   }
   return killerPerks;
 }
@@ -65,7 +69,7 @@ List<Perk> returnKiller() {
 List<Perk> returnSurvivor() {
   List<Perk> survivorPerks = List<Perk>();
   for(var i=0;i<survivorList.length;i++) {
-    survivorPerks.add(Perk(survivorList[i],true,i));
+    survivorPerks.add(Perk(survivorList[i],true,i,"${i + 1}.png"));
   }
   return survivorPerks;
 }


### PR DESCRIPTION
Added a check on press of the save button to display a snackbar in the event that they have less than 4 perks selected in either category (survivor/killer) instead of popping the context.