### PR TITLE
Fix decoding of Build ID for killer

### DIFF
--- a/lib/classes/perkSerialiser.dart
+++ b/lib/classes/perkSerialiser.dart
@@ -51,7 +51,7 @@ class PerksSerialiser {
         perkType = PerkType.survivor;
         break;
       case 4:
-        perkType = PerkType.survivor;
+        perkType = PerkType.killer;
         break;
     }
 


### PR DESCRIPTION
PerkType for decoded killer builds were incorrectly set as survivor