### PR TITLE
Added padding to the floatingActionButton & the container to now find…

### DIFF
--- a/lib/pages/perkPage.dart
+++ b/lib/pages/perkPage.dart
@@ -184,7 +184,7 @@ class _PerkPageState extends State<PerkPage> {
         title: Text('PerkLight'),
       ),
       floatingActionButton: Padding(
-        padding: EdgeInsets.only(bottom: MediaQuery.of(context).size.height / 100) * 5,
+        padding: EdgeInsets.only(bottom: MediaQuery.of(context).size.height * 0.05),
         child: Transform.scale(
           scale: 1.2,
           child: FloatingActionButton.extended(
@@ -261,7 +261,7 @@ class _PerkPageState extends State<PerkPage> {
                   ),
                 ),
                 Container(
-                  height: MediaQuery.of(context).size.height / 100 * 13
+                  height: MediaQuery.of(context).size.height * 0.13
                 )
               ]
             );

--- a/lib/pages/perkPage.dart
+++ b/lib/pages/perkPage.dart
@@ -183,14 +183,20 @@ class _PerkPageState extends State<PerkPage> {
       appBar: AppBar(
         title: Text('PerkLight'),
       ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () async {
-          setState(() {
-            _rollTileCallback(ALL_TILES, context);
-          });
-        },
-        label: Text('Randomise'),
-        icon: Icon(Icons.casino),
+      floatingActionButton: Padding(
+        padding: EdgeInsets.only(bottom: MediaQuery.of(context).size.height / 100) * 5,
+        child: Transform.scale(
+          scale: 1.2,
+          child: FloatingActionButton.extended(
+            onPressed: () async {
+              setState(() {
+                _rollTileCallback(ALL_TILES, context);
+              });
+            },
+            label: Text('Randomise'),
+            icon: Icon(Icons.casino),
+          ),
+        ),
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
       body: SafeArea(
@@ -255,7 +261,7 @@ class _PerkPageState extends State<PerkPage> {
                   ),
                 ),
                 Container(
-                  height: 50.0
+                  height: MediaQuery.of(context).size.height / 100 * 13
                 )
               ]
             );


### PR DESCRIPTION
… the device height and dynamically assign it to ensure the button and toggle never overlap. I have tested this on small screen sizes and although the icons clip ( the perk icons ) this fix does work for the randomise button. Also added some scale for the button as I felt it was a little small.