### PR TITLE
Extracted the Navigation Drawer into a separate component

### DIFF
--- a/lib/pages/perkPage.dart
+++ b/lib/pages/perkPage.dart
@@ -8,6 +8,7 @@ import 'package:perklight/classes/item.dart';
 import 'package:perklight/classes/perkSerialiser.dart';
 import 'package:perklight/utilities.dart' as Utils;
 import 'package:perklight/widgets/perkTile.dart';
+import 'package:perklight/widgets/navigationDrawer.dart';
 
 class PerkPage extends StatefulWidget {
   PerkPage(arguments)
@@ -120,85 +121,18 @@ class _PerkPageState extends State<PerkPage> {
     ]);
 
     return Scaffold(
-      drawer: Drawer(
-        child: Container(
-          child: ListView(
-            children: <Widget>[
-              Container(
-                child: DrawerHeader(
-                  child: Center(
-                    child: Text(
-                      'PerkLight',
-                      style: TextStyle(fontSize: 40.0, fontWeight: FontWeight.bold, color: Colors.white),
-                    ),
-                  ),
-                ),
-              ),
-              Container(
-                padding: EdgeInsets.all(24.0),
-                child: ListTile(
-                  title: Text(
-                    'Perk Configuration',
-                    style: TextStyle(
-                      fontWeight: FontWeight.w700,
-                      fontSize: 22.0,
-                    ),
-                  ),
-                  onTap: () async {
-                    await Navigator.pushNamed(context, '/builder',
-                        arguments: {'killerPerks': widget.killerPerks, 'survivorPerks': widget.survivorPerks});
-                    setState(() {
-                      _filteredRoll();
-                    });
-                  },
-                ),
-              ),
-              Container(
-                padding: EdgeInsets.all(24.0),
-                child: ListTile(
-                  title: Text(
-                    'Character Profiles',
-                    style: TextStyle(
-                      fontWeight: FontWeight.w700,
-                      fontSize: 22.0,
-                    ),
-                  ),
-                  onTap: () async {
-                    await Navigator.pushNamed(context, '/characters', arguments: {
-                      'killerPerks': widget.killerPerks,
-                      'survivorPerks': widget.survivorPerks,
-                      'survivorCharacterDetails': widget.survivorCharacterDetails,
-                      'killerCharacterDetails': widget.killerCharacterDetails
-                    });
-                  },
-                ),
-              ),
-              Container(
-                padding: EdgeInsets.all(24.0),
-                child: ListTile(
-                  title: Text(
-                    'Item Library',
-                    style: TextStyle(
-                      fontWeight: FontWeight.w700,
-                      fontSize: 22.0,
-                    ),
-                  ),
-                  onTap: () async {
-                    await Navigator.pushNamed(context, '/items', arguments: {
-                      'firecracker': widget.firecrackerItemDetails,
-                      'flashlight': widget.flashlightItemDetails,
-                      'key': widget.keyItemDetails,
-                      'map': widget.mapItemDetails,
-                      'medkit': widget.medkitItemDetails,
-                      'toolbox': widget.toolboxItemDetails
-                    });
-                  },
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
+      drawer: NavigationDrawer({
+        'killerPerks': widget.killerPerks,
+        'survivorPerks': widget.survivorPerks,
+        'survivorCharacterDetails': widget.survivorCharacterDetails,
+        'killerCharacterDetails': widget.killerCharacterDetails,
+        'firecrackerItemDetails': widget.firecrackerItemDetails,
+        'flashlightItemDetails': widget.flashlightItemDetails,
+        'keyItemDetails': widget.keyItemDetails,
+        'mapItemDetails': widget.mapItemDetails,
+        'medkitItemDetails': widget.medkitItemDetails,
+        'toolboxItemDetails': widget.toolboxItemDetails
+      }),
       appBar: AppBar(
         title: Text('PerkLight'),
       ),

--- a/lib/widgets/navigationDrawer.dart
+++ b/lib/widgets/navigationDrawer.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:perklight/classes/character.dart';
+import 'package:perklight/classes/item.dart';
+import 'package:perklight/classes/perk.dart';
+
+class NavigationDrawer extends StatelessWidget {
+  NavigationDrawer(arguments)
+      : killerPerks = arguments['killerPerks'],
+        survivorPerks = arguments['survivorPerks'],
+        survivorCharacterDetails = arguments['survivorCharacterDetails'],
+        killerCharacterDetails = arguments['killerCharacterDetails'],
+        firecrackerItemDetails = arguments['firecrackerItemDetails'],
+        flashlightItemDetails = arguments['flashlightItemDetails'],
+        keyItemDetails = arguments['keyItemDetails'],
+        mapItemDetails = arguments['mapItemDetails'],
+        medkitItemDetails = arguments['medkitItemDetails'],
+        toolboxItemDetails = arguments['toolboxItemDetails'];
+
+  final List<KillerPerk> killerPerks;
+  final List<SurvivorPerk> survivorPerks;
+  final List<Character> survivorCharacterDetails;
+  final List<Character> killerCharacterDetails;
+  final List<Item> firecrackerItemDetails;
+  final List<Item> flashlightItemDetails;
+  final List<Item> keyItemDetails;
+  final List<Item> mapItemDetails;
+  final List<Item> medkitItemDetails;
+  final List<Item> toolboxItemDetails;
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+        child: Column(children: [
+      const DrawerHeader(child: Text('PerkLight')),
+      Expanded(
+          child: ListView(padding: EdgeInsets.zero, children: [
+        ListTile(
+            title: Text('Perk Configuration'),
+            onTap: () async {
+              await Navigator.pushNamed(context, '/builder',
+                  arguments: {'killerPerks': this.killerPerks, 'survivorPerks': this.survivorPerks});
+            }),
+        ListTile(
+            title: Text('Character Profiles'),
+            onTap: () async {
+              await Navigator.pushNamed(context, '/characters', arguments: {
+                'survivorCharacterDetails': this.survivorCharacterDetails,
+                'killerCharacterDetails': this.killerCharacterDetails
+              });
+            }),
+        ListTile(
+            title: Text('Item Library'),
+            onTap: () async {
+              await Navigator.pushNamed(context, '/items', arguments: {
+                'firecracker': this.firecrackerItemDetails,
+                'flashlight': this.flashlightItemDetails,
+                'key': this.keyItemDetails,
+                'map': this.mapItemDetails,
+                'medkit': this.medkitItemDetails,
+                'toolbox': this.toolboxItemDetails
+              });
+            }),
+      ]))
+    ]));
+  }
+}

--- a/lib/widgets/navigationDrawer.dart
+++ b/lib/widgets/navigationDrawer.dart
@@ -32,16 +32,19 @@ class NavigationDrawer extends StatelessWidget {
   Widget build(BuildContext context) {
     return Drawer(
         child: Column(children: [
-      const DrawerHeader(child: Text('PerkLight')),
+      DrawerHeader(
+          child: Container(alignment: Alignment.center, child: Text('PerkLight', style: TextStyle(fontSize: 30.0)))),
       Expanded(
           child: ListView(padding: EdgeInsets.zero, children: [
         ListTile(
+            leading: Icon(Icons.check_box_outlined),
             title: Text('Perk Configuration'),
             onTap: () async {
               await Navigator.pushNamed(context, '/builder',
                   arguments: {'killerPerks': this.killerPerks, 'survivorPerks': this.survivorPerks});
             }),
         ListTile(
+            leading: Icon(Icons.account_box),
             title: Text('Character Profiles'),
             onTap: () async {
               await Navigator.pushNamed(context, '/characters', arguments: {
@@ -50,6 +53,7 @@ class NavigationDrawer extends StatelessWidget {
               });
             }),
         ListTile(
+            leading: Icon(Icons.flashlight_on),
             title: Text('Item Library'),
             onTap: () async {
               await Navigator.pushNamed(context, '/items', arguments: {


### PR DESCRIPTION
**Note:** Based on (and targetting) the as-yet unmerged matt/fix-deprecation-issues branch. Please merge that branch first then retarget this one to dev.

Extracted the navigation drawer out of the PerkPage widget and into it's own widget for better encapsulation and to improve readability of the perkPage widget.